### PR TITLE
refactor: Drawable 생성자 추가, 좌표값을 float 타입으로 관리하도록 변경

### DIFF
--- a/Main/Drawable.pde
+++ b/Main/Drawable.pde
@@ -1,8 +1,8 @@
 public class Drawable {
-  protected int abstractX;
-  protected int abstractY;
-  protected int w;
-  protected int h;
+  protected float x;
+  protected float y;
+  protected float w;
+  protected float h;
   protected float zAngle;
   protected int zIndex;
   protected PVector startPos;
@@ -10,9 +10,21 @@ public class Drawable {
   protected PVector center;
   protected PVector scale;
   
-  public void setup(int x, int y, int w, int h, int zIndex){
-    this.abstractX = x;
-    this.abstractY = y;
+  public Drawable() {
+    this.setup(0, 0, 0, 0, 0);
+  }
+
+  public Drawable(float x, float y, float w, float h) {
+    this.setup(x, y, w, h, 0);
+  }
+
+  public Drawable(float x, float y, float w, float h, int zIndex) {
+    this.setup(x, y, w, h, zIndex);
+  }
+  
+  public void setup(float x, float y, float w, float h, int zIndex){
+    this.x = x;
+    this.y = y;
     this.w = w;
     this.h = h;
     this.zAngle = 0;
@@ -24,12 +36,12 @@ public class Drawable {
     this.scale = new PVector(1, 1);
   }
 
-  public int getX() { return abstractX; }
-  public int getY() { return abstractY; }
+  public float getX() { return x; }
+  public float getY() { return y; }
 
-  public void setPosition(int x, int y) {
-    this.abstractX = x;
-    this.abstractY = y;
+  public void setPosition(float x, float y) {
+    this.x = x;
+    this.y = y;
   }
 
   public float getScaleX() { return scale.x; }
@@ -54,12 +66,11 @@ public class Drawable {
   }
   
   public boolean mousePressed(){
-    // System.out.println("Mouse Pressed"+ "||" + mouseX+ "||" + mouseY+ "||" + this.abstractX+ "||" + this.abstractY+ "||" + this.w+ "||" + this.h);
     if(
-      mouseX > this.abstractX 
-      && mouseX < this.abstractX + this.w
-      && mouseY > this.abstractY 
-      && mouseY < this.abstractY + this.h
+      mouseX > this.x 
+      && mouseX < this.x + this.w
+      && mouseY > this.y 
+      && mouseY < this.y + this.h
     ){
       this.onClick();
       return true;

--- a/Main/Ground.pde
+++ b/Main/Ground.pde
@@ -1,31 +1,14 @@
 public class Ground extends Drawable {
-    int x;
-    int y;
-    int w;
-    int h;
-    int zIndex;
     color c;
 
     public Ground(int zIndex, color c) {
-      super();
-      this.x = 0;
-      this.y = height / 5 * 4;
-      this.w = width;
-      this.h = height / 5;
-      this.zIndex = zIndex;
+      super(0, height / 5 * 4, width, height / 5, zIndex);
       this.c = c;
     }
 
     public Ground(int x, int y, int w, int h, int zIndex, color c) {
-        super();
-        this.x = x;
-        this.y = y;
-        this.w = w;
-        this.h = h;
-        this.zIndex = zIndex;
+        super(x, y, w, h, zIndex);
         this.c = c;
-
-        this.setup(this.x, this.y, this.w, this.h, this.zIndex);
     }
 
     @Override

--- a/Main/Objects.pde
+++ b/Main/Objects.pde
@@ -102,7 +102,7 @@ public class ShapeObject extends Drawable {
     noStroke();
     shapeMode(CENTER);
     rotate(zAngle);
-    shape(shape, abstractX, abstractY, w, h);
+    shape(shape, x, y, w, h);
 
     popStyle();
   }
@@ -112,8 +112,7 @@ public class ShapeObject extends Drawable {
     
     imageMode(CENTER);
     rotate(zAngle);
-    //image(image, position.x, position.y, size.x, size.y);
-    image(image, abstractX, abstractY, image.width * scale.x, image.height * scale.y);
+    image(image, x, y, image.width * scale.x, image.height * scale.y);
 
     popStyle();
   }

--- a/Main/Rock.pde
+++ b/Main/Rock.pde
@@ -1,13 +1,11 @@
 public class Rock extends Drawable {
-    int zIndex;
-    public Rock(int x, int y, int w, int h, int zIndex) {
-        super();
-        this.setup(x,y,w,h,zIndex);
+    public Rock(float x, float y, float w, float h, int zIndex) {
+        super(x, y, w, h, zIndex);
     }
 
     @Override
     public void draw() {
-        rect(this.abstractX, this.abstractY, this.w, this.h);
+        rect(this.x, this.y, this.w, this.h);
     }
 
     @Override


### PR DESCRIPTION
### 변경사항
- Drawable에서 x, y 좌표값과 width, height를 float 타입으로 관리하도록 변경
  - 이펙트 매니저 만들 때 float 타입을 사용해서 조금 더 세밀한 좌표값 관리를 하려고 합니다.
- Drawable 생성자 추가
  - 상속받는 클래스에서 부모 생성자 호출할 때 변수 초기화하지 않고, 따로 `this.x = x` 로 초기화하는 부분이 이상한 것 같아서 변경했습니다.