### PR TITLE
fix: dialog UI 에서 줄바꿈 문자가 그대로 표시되는 오류 수정, 폰트 사이즈 조절

### DIFF
--- a/Main/DialogUi.pde
+++ b/Main/DialogUi.pde
@@ -2,7 +2,7 @@ int DIALOG_HEIGHT = 200;
 int DIALOG_PADDING = 16;
 int DIALOG_MARGIN = 10;
 int TELLER_TEXT_SIZE = 24;
-int MSG_TEXT_SIZE = 28;
+int MSG_TEXT_SIZE = 16;
 
 import java.util.Queue;
 import java.util.LinkedList;
@@ -38,8 +38,8 @@ public class DialogUi {
         }
         //textSize(MSG_TEXT_SIZE);
         fill(0, 0, 0);
-        
-        fontManager.drawText(this.current.text, x + DIALOG_PADDING, textAnchor, width/2 - DIALOG_PADDING*2, 1000, MSG_TEXT_SIZE);
+        String msg = this.current.text.replace("\\n","\n");
+        fontManager.drawText(msg, x + DIALOG_PADDING, textAnchor, width/2 - DIALOG_PADDING*2, 1000, MSG_TEXT_SIZE);
         //text(this.current.text,
         //x + DIALOG_PADDING,
         //textAnchor,


### PR DESCRIPTION
AS-IS
<img width="1278" alt="스크린샷 2024-05-27 21 01 40" src="https://github.com/ddalpange/ssu-processing/assets/12093323/f8b129e5-acf2-4b59-aa5f-5c6ed40070d1">

TO-BE
<img width="1280" alt="스크린샷 2024-05-27 21 01 59" src="https://github.com/ddalpange/ssu-processing/assets/12093323/a1aa22c2-9086-446a-a738-ddf58a133aad">


