### PR TITLE
[Fix] 줌인 시 이미지 중복 버그

### DIFF
--- a/Main/Main.pde
+++ b/Main/Main.pde
@@ -22,9 +22,14 @@ void draw() {
 
   background(255);
   BaseScene scene = sceneManager.getCurrentScene();
+  
+  pushMatrix();
+  resetMatrix();
 
   cameraManager.draw(); 
   sceneManager.Draw();
+  
+  popMatrix();
 
   postProcessManager.draw();
   image(get(), 0, 0, width, height);


### PR DESCRIPTION
줌인으로 캔버스 영역을 벗어나면 이미지가 중복해서 그려지는 버그 수정

기본 캔버스 화면이 보여지는 영역에 검은색 테두리가 존재 깨달음 -> 확인 필요...

**수정 전**
<img width="1275" alt="스크린샷 2024-06-03 오전 1 18 37" src="https://github.com/ddalpange/ssu-processing/assets/44323898/eda39a2b-ee74-4bcd-b73f-5e5c9eec6350">

**수정 후**
<img width="1275" alt="스크린샷 2024-06-03 오전 1 22 12" src="https://github.com/ddalpange/ssu-processing/assets/44323898/c5b5dd1d-037c-48ad-93b6-c9181df400e2">

